### PR TITLE
Dev - Bing Geolocation

### DIFF
--- a/BingWebSearch.py
+++ b/BingWebSearch.py
@@ -2,20 +2,40 @@ import json
 import os
 from pprint import pprint
 import requests
+from geopy.geocoders import Nominatim
 
 '''
 Module for bing search
 '''
 
-def make_bing_query(query, mkt = 'en-US'):
+def get_location(location = "Columbus, OH"):
+    geolocator = Nominatim(user_agent = "CS356-proj")
+    geolocation = geolocator.geocode(location)
+    return geolocation
+
+
+
+def make_bing_query(query, mkt = 'en-US', location = "Columbus, OH"):
     # Add API key and endpoint from environment variables
     subscription_key = os.environ['BING_SEARCH_V7_SUBSCRIPTION_KEY']
     endpoint = os.environ['BING_SEARCH_V7_ENDPOINT'] + "/v7.0/search"
 
     # Construct request
-    view = '47.6421,-122.13715,5000'
-    params = {'q': query, 'mkt': mkt, 'localCircularView': view }
-    headers = {'Ocp-Apim-Subscription-Key': subscription_key }
+    #view = '47.6421,-122.13715,5000' # need to test if this is being used for more than Maps
+    # test search location header: Columbus, OH
+    # search_location = 'lat:39.9612;long:82.9988;re:5000;disp:Columbus%2C%20Ohio'
+    geolocation = get_location(location)
+    search_location = f"lat:{geolocation.latitude};long:{geolocation.longitude};re:5000"
+
+    params = {
+        'q': query,
+        #'localCircularView': view
+    }
+    headers = {
+        'Ocp-Apim-Subscription-Key': subscription_key,
+        'X-Search-Location': search_location,
+        #'X-MSEdge-Client-IP': '18.118.156.85'
+    }
 
     # call API
     try:

--- a/BingWebSearch.py
+++ b/BingWebSearch.py
@@ -7,14 +7,14 @@ import requests
 Module for bing search
 '''
 
-def make_bing_query(query):
+def make_bing_query(query, mkt = 'en-US'):
     # Add API key and endpoint from environment variables
     subscription_key = os.environ['BING_SEARCH_V7_SUBSCRIPTION_KEY']
     endpoint = os.environ['BING_SEARCH_V7_ENDPOINT'] + "/v7.0/search"
 
     # Construct request
-    mkt = 'en-US'
-    params = {'q': query, 'mkt': mkt}
+    view = '47.6421,-122.13715,5000'
+    params = {'q': query, 'mkt': mkt, 'localCircularView': view }
     headers = {'Ocp-Apim-Subscription-Key': subscription_key }
 
     # call API

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ msrest
 azure-common
 msrestazure
 azure-core
+geopy

--- a/webscraper.py
+++ b/webscraper.py
@@ -20,6 +20,6 @@ def get_bing_results(keyword, mkt='en-US'):
 
 
 keyword = 'pizza'
-# get_ddg_results(keyword=keyword)
-# get_google_results(keyword=keyword, location="Boston,Massachusetts,United States")
-get_bing_results(keyword=keyword, mkt='en-UK')
+get_ddg_results(keyword=keyword)
+get_google_results(keyword=keyword, location="Boston,Massachusetts,United States")
+get_bing_results(keyword=keyword)

--- a/webscraper.py
+++ b/webscraper.py
@@ -15,11 +15,11 @@ def get_google_results(keyword, location, max_results=10):
     for result in g_results:
         print(result)
 
-def get_bing_results(keyword):
+def get_bing_results(keyword, mkt='en-US'):
     make_bing_query(keyword)
 
 
 keyword = 'pizza'
-get_ddg_results(keyword=keyword)
-get_google_results(keyword=keyword, location="Boston,Massachusetts,United States")
-get_bing_results(keyword=keyword)
+# get_ddg_results(keyword=keyword)
+# get_google_results(keyword=keyword, location="Boston,Massachusetts,United States")
+get_bing_results(keyword=keyword, mkt='en-UK')

--- a/webscraper.py
+++ b/webscraper.py
@@ -15,11 +15,11 @@ def get_google_results(keyword, location, max_results=10):
     for result in g_results:
         print(result)
 
-def get_bing_results(keyword, mkt='en-US'):
-    make_bing_query(keyword)
+def get_bing_results(keyword, mkt='en-US', location='New York, NY'):
+    make_bing_query(keyword, mkt, location)
 
 
 keyword = 'pizza'
 get_ddg_results(keyword=keyword)
 get_google_results(keyword=keyword, location="Boston,Massachusetts,United States")
-get_bing_results(keyword=keyword)
+get_bing_results(keyword=keyword, mkt='en-US', location='Boston, MA')


### PR DESCRIPTION
Added geolocation support to Bing search.
- The Bing API uses a request header 'X-Search-Location' based on latitude and longitude to give location-based results, at least for the maps portion of its search page. Added support to incorporate geolocation with Bing query automation.
- Todo: compare results against instance in actual location.